### PR TITLE
Required Properties

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>io.wcm</groupId>
     <artifactId>io.wcm.caconfig.editor.parent</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.caconfig.editor</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Context-Aware Configuration Editor</name>
@@ -42,7 +42,7 @@
     <site.url.module.prefix>caconfig/editor/bundle</site.url.module.prefix>
 
     <!-- Enable reproducible builds -->
-    <project.build.outputTimestamp>2022-08-24T11:41:54Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2022-09-20T14:22:41Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>

--- a/bundle/src/main/java/io/wcm/caconfig/editor/EditorProperties.java
+++ b/bundle/src/main/java/io/wcm/caconfig/editor/EditorProperties.java
@@ -99,10 +99,9 @@ public final class EditorProperties {
   public static final String PROPERTY_TAGBROWSER_ROOT_PATH_PROVIDER = "tagbrowserRootPathProvider";
 
   /**
-   * Define this property as mandatory. Configuration cannot be saved if no value is given.
-   * Not supported for boolean properties.
+   * Define this property as required/mandatory. Configuration cannot be saved if no value is given.
    */
-  public static final String PROPERTY_MANDATORY = "mandatory";
+  public static final String PROPERTY_REQUIRED = "required";
 
   /**
    * Property name for defining a custom validation for a string or numeric parameter.

--- a/bundle/src/main/java/io/wcm/caconfig/editor/EditorProperties.java
+++ b/bundle/src/main/java/io/wcm/caconfig/editor/EditorProperties.java
@@ -99,6 +99,12 @@ public final class EditorProperties {
   public static final String PROPERTY_TAGBROWSER_ROOT_PATH_PROVIDER = "tagbrowserRootPathProvider";
 
   /**
+   * Define this property as mandatory. Configuration cannot be saved if no value is given.
+   * Not supported for boolean properties.
+   */
+  public static final String PROPERTY_MANDATORY = "mandatory";
+
+  /**
    * Property name for defining a custom validation for a string or numeric parameter.
    * The value is either a name of a Granite UI Foundation Validator, or a registered custom validation method.
    * See <a href="https://wcm.io/caconfig/editor/validation.html">documentation</a> for details.

--- a/bundle/src/main/java/io/wcm/caconfig/editor/package-info.java
+++ b/bundle/src/main/java/io/wcm/caconfig/editor/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Configuration editor API.
  */
-@org.osgi.annotation.versioning.Version("1.7")
+@org.osgi.annotation.versioning.Version("1.8")
 package io.wcm.caconfig.editor;

--- a/bundle/src/main/resources/angularjs-partials/multifield.html
+++ b/bundle/src/main/resources/angularjs-partials/multifield.html
@@ -71,11 +71,13 @@
   </div>
 
   <div class="caconfig-multifield caconfig-if-config-not-inherited caconfig-if-property-not-overridden-and-not-inherited"
-       ng-repeat="value in values" ng-form="inputTextForm">
-    <label class="coral-Checkbox"
+       ng-repeat="value in values" ng-form="inputMultifieldForm">
+    <label class="coral-Checkbox" style="margin-right:10px;"
            bo-if="type==='checkbox'">
       <input class="coral-Checkbox-input" type="checkbox"
-             ng-model="value.value" />
+             ng-model="value.value"
+             ng-required="{{property.metadata.properties.required}}"
+             name="inputField"/>
       <span class="coral-Checkbox-checkmark"></span>
     </label>
     <div class="caconfig-textfield-wrapper">
@@ -84,9 +86,11 @@
              ng-model="value.value"
              ng-trim="false"
              ng-pattern="pattern"
+             ng-required="{{property.metadata.properties.required}}"
              caconfig-validation="{{validation}}"
-             name="textField"/>
-      <div class="coral-Form-errorlabel" ng-if="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
+             name="inputField"/>
+      <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputMultifieldForm.inputField.$error.required" bo-text="i18n('validation.required')"></div>
+      <div class="coral-Form-errorlabel" ng-if="validationMessage" ng-show="inputMultifieldForm.inputField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
     </div>
     <div class="coral-ButtonGroup _coral-ButtonGroup coral3-ButtonGroup">
       <button class="coral-ButtonGroup-item coral3-ButtonGroup-item caconfig-disableable-button"

--- a/bundle/src/main/resources/angularjs-partials/multifield.html
+++ b/bundle/src/main/resources/angularjs-partials/multifield.html
@@ -76,7 +76,7 @@
            bo-if="type==='checkbox'">
       <input class="coral-Checkbox-input" type="checkbox"
              ng-model="value.value"
-             ng-required="{{property.metadata.properties.required}}"
+             ng-required="{{property.metadata.properties.required && !property.overridden && !property.inherited}}"
              name="inputField"/>
       <span class="coral-Checkbox-checkmark"></span>
     </label>
@@ -86,7 +86,7 @@
              ng-model="value.value"
              ng-trim="false"
              ng-pattern="pattern"
-             ng-required="{{property.metadata.properties.required}}"
+             ng-required="{{property.metadata.properties.required && !property.overridden && !property.inherited}}"
              caconfig-validation="{{validation}}"
              name="inputField"/>
       <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputMultifieldForm.inputField.$error.required" bo-text="i18n('validation.required')"></div>

--- a/bundle/src/main/resources/angularjs-partials/multifield.html
+++ b/bundle/src/main/resources/angularjs-partials/multifield.html
@@ -86,7 +86,7 @@
              ng-pattern="pattern"
              caconfig-validation="{{validation}}"
              name="textField"/>
-      <div class="caconfig-invalid-message" ng-if="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation">{{validationMessage}}</div>
+      <div class="coral-Form-errorlabel" ng-if="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
     </div>
     <div class="coral-ButtonGroup _coral-ButtonGroup coral3-ButtonGroup">
       <button class="coral-ButtonGroup-item coral3-ButtonGroup-item caconfig-disableable-button"

--- a/bundle/src/main/resources/angularjs-partials/multifield.html
+++ b/bundle/src/main/resources/angularjs-partials/multifield.html
@@ -89,8 +89,8 @@
              ng-required="{{property.metadata.properties.required}}"
              caconfig-validation="{{validation}}"
              name="inputField"/>
-      <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputMultifieldForm.inputField.$error.required" bo-text="i18n('validation.required')"></div>
-      <div class="coral-Form-errorlabel" ng-if="validationMessage" ng-show="inputMultifieldForm.inputField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
+      <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputMultifieldForm.inputField.$error.required" bo-text="i18n('validation.required')"></div>
+      <div class="coral-Form-errorlabel" bindonce="validationMessage" ng-show="inputMultifieldForm.inputField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
     </div>
     <div class="coral-ButtonGroup _coral-ButtonGroup coral3-ButtonGroup">
       <button class="coral-ButtonGroup-item coral3-ButtonGroup-item caconfig-disableable-button"

--- a/bundle/src/main/resources/angularjs-partials/pathbrowser.html
+++ b/bundle/src/main/resources/angularjs-partials/pathbrowser.html
@@ -1,10 +1,12 @@
 <div bindonce class="caconfig-pathbrowser" ng-form="inputPathBrowserForm">
 
-  <foundation-autocomplete class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
-    <coral-overlay foundation-autocomplete-suggestion class="foundation-picker-buttonlist"></coral-overlay>
-    <coral-taglist foundation-autocomplete-value></coral-taglist>
-  </foundation-autocomplete>
-  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputPathBrowserForm.pathBrowser.$error.required" bo-text="i18n('validation.required')"></div>
+  <div class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
+    <foundation-autocomplete>
+      <coral-overlay foundation-autocomplete-suggestion class="foundation-picker-buttonlist"></coral-overlay>
+      <coral-taglist foundation-autocomplete-value></coral-taglist>
+    </foundation-autocomplete>
+    <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputPathBrowserForm.pathBrowser.$error.required" bo-text="i18n('validation.required')"></div>
+  </div>
 
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
          ng-model="property.value"

--- a/bundle/src/main/resources/angularjs-partials/pathbrowser.html
+++ b/bundle/src/main/resources/angularjs-partials/pathbrowser.html
@@ -1,9 +1,10 @@
-<div bindonce class="caconfig-pathbrowser">
+<div bindonce class="caconfig-pathbrowser" ng-form="inputPathBrowserForm">
 
   <foundation-autocomplete class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
     <coral-overlay foundation-autocomplete-suggestion class="foundation-picker-buttonlist"></coral-overlay>
     <coral-taglist foundation-autocomplete-value></coral-taglist>
   </foundation-autocomplete>
+  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputPathBrowserForm.pathBrowser.$error.required" bo-text="i18n('validation.required')"></div>
 
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
          ng-model="property.value"

--- a/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
@@ -2,7 +2,7 @@
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
     <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
            ng-model="property.value"
-           ng-required="{{property.metadata.properties.mandatory}}"
+           ng-required="{{property.metadata.properties.required}}"
            name="checkbox"/>
     <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
   </label>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
@@ -1,12 +1,14 @@
 <div ng-form="inputCheckboxForm">
-  <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
-    <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
-           ng-model="property.value"
-           ng-required="{{property.metadata.properties.required}}"
-           name="checkbox"/>
-    <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
-  </label>
-  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputCheckboxForm.checkbox.$error.required" bo-text="i18n('validation.required')"></div>
+  <div class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
+    <label>
+      <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
+             ng-model="property.value"
+             ng-required="{{property.metadata.properties.required}}"
+             name="checkbox"/>
+      <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
+    </label>
+    <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputCheckboxForm.checkbox.$error.required" bo-text="i18n('validation.required')"></div>
+  </div>
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited">
     <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
            ng-model="property.value"

--- a/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
@@ -1,4 +1,4 @@
-<div ng-form="inputCheckbox">
+<div ng-form="inputCheckboxForm">
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
     <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
            ng-model="property.value"
@@ -6,7 +6,7 @@
            name="checkbox"/>
     <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
   </label>
-  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputCheckbox.checkbox.$error.required" bo-text="i18n('validation.required')"></div>
+  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputCheckboxForm.checkbox.$error.required" bo-text="i18n('validation.required')"></div>
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited">
     <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
            ng-model="property.value"

--- a/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
@@ -1,12 +1,14 @@
 <div ng-form="inputCheckboxForm">
-  <div class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
-    <label>
-      <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
-             ng-model="property.value"
-             ng-required="{{property.metadata.properties.required}}"
-             name="checkbox"/>
-      <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
-    </label>
+  <div class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
+    <div class="coral-Checkbox coral3-Checkbox">
+      <label>
+        <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
+               ng-model="property.value"
+               ng-required="{{property.metadata.properties.required}}"
+               name="checkbox"/>
+        <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
+      </label>
+    </div>
     <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputCheckboxForm.checkbox.$error.required" bo-text="i18n('validation.required')"></div>
   </div>
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited">

--- a/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
@@ -1,9 +1,12 @@
-<div>
+<div ng-form="inputCheckbox">
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
     <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
-           ng-model="property.value" />
+           ng-model="property.value"
+           ng-required="{{property.metadata.properties.mandatory}}"
+           name="checkbox"/>
     <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
   </label>
+  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputCheckbox.checkbox.$error.required" bo-text="i18n('validation.required')"></div>
   <label class="coral-Checkbox coral3-Checkbox caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited">
     <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
            ng-model="property.value"

--- a/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputCheckbox.html
@@ -4,7 +4,7 @@
       <label>
         <input class="coral-Checkbox-input coral3-Checkbox-input" type="checkbox"
                ng-model="property.value"
-               ng-required="{{property.metadata.properties.required}}"
+               ng-required="{{property.metadata.properties.required && !property.overridden && !property.inherited}}"
                name="checkbox"/>
         <span class="coral-Checkbox-checkmark coral3-Checkbox-checkmark"></span>
       </label>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputText.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputText.html
@@ -1,12 +1,14 @@
 <div ng-form="inputTextForm">
-  <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
-         ng-model="property.value" ng-trim="false"
-         ng-pattern="pattern"
-         ng-required="{{property.metadata.properties.required}}"
-         caconfig-validation="{{validation}}"
-         name="textField"/>
-  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextForm.textField.$error.required" bo-text="i18n('validation.required')"></div>
-  <div class="coral-Form-errorlabel" ng-if="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
+  <div class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
+    <input is="coral-textfield"
+           ng-model="property.value" ng-trim="false"
+           ng-pattern="pattern"
+           ng-required="{{property.metadata.properties.required}}"
+           caconfig-validation="{{validation}}"
+           name="textField"/>
+    <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputTextForm.textField.$error.required" bo-text="i18n('validation.required')"></div>
+    <div class="coral-Form-errorlabel" bindonce="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
+  </div>
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
          ng-model="property.value"
          disabled readonly />

--- a/bundle/src/main/resources/angularjs-partials/propertyInputText.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputText.html
@@ -2,7 +2,7 @@
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
          ng-model="property.value" ng-trim="false"
          ng-pattern="pattern"
-         ng-required="{{property.metadata.properties.mandatory}}"
+         ng-required="{{property.metadata.properties.required}}"
          caconfig-validation="{{validation}}"
          name="textField"/>
   <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextForm.textField.$error.required" bo-text="i18n('validation.required')"></div>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputText.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputText.html
@@ -3,7 +3,7 @@
     <input is="coral-textfield"
            ng-model="property.value" ng-trim="false"
            ng-pattern="pattern"
-           ng-required="{{property.metadata.properties.required}}"
+           ng-required="{{property.metadata.properties.required && !property.overridden && !property.inherited}}"
            caconfig-validation="{{validation}}"
            name="textField"/>
     <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputTextForm.textField.$error.required" bo-text="i18n('validation.required')"></div>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputText.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputText.html
@@ -2,9 +2,11 @@
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
          ng-model="property.value" ng-trim="false"
          ng-pattern="pattern"
+         ng-required="{{property.metadata.properties.mandatory}}"
          caconfig-validation="{{validation}}"
          name="textField"/>
-  <div class="caconfig-invalid-message" ng-if="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation">{{validationMessage}}</div>
+  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextForm.textField.$error.required" bo-text="i18n('validation.required')"></div>
+  <div class="coral-Form-errorlabel" ng-if="validationMessage" ng-show="inputTextForm.textField.$error.caconfigValidation || inputTextForm.textField.$pending.caconfigValidation" bo-text="validationMessage"></div>
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
          ng-model="property.value"
          disabled readonly />

--- a/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
@@ -1,9 +1,11 @@
 <div ng-form="inputTextAreaForm">
-  <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
-            ng-model="property.value" ng-trim="false"
-            ng-required="{{property.metadata.properties.required}}"
-            name="textArea"></textarea>
-  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextAreaForm.textArea.$error.required" bo-text="i18n('validation.required')"></div>
+  <div class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
+    <textarea is="coral-textarea"
+              ng-model="property.value" ng-trim="false"
+              ng-required="{{property.metadata.properties.required}}"
+              name="textArea"></textarea>
+    <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputTextAreaForm.textArea.$error.required" bo-text="i18n('validation.required')"></div>
+  </div>
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
             ng-model="property.value"
             disabled readonly></textarea>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
@@ -1,7 +1,7 @@
 <div ng-form="inputTextArea">
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
             ng-model="property.value" ng-trim="false"
-            ng-required="{{property.metadata.properties.mandatory}}"
+            ng-required="{{property.metadata.properties.required}}"
             name="textArea"></textarea>
   <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextArea.textArea.$error.required" bo-text="i18n('validation.required')"></div>
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"

--- a/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
@@ -2,7 +2,7 @@
   <div class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited">
     <textarea is="coral-textarea"
               ng-model="property.value" ng-trim="false"
-              ng-required="{{property.metadata.properties.required}}"
+              ng-required="{{property.metadata.properties.required && !property.overridden && !property.inherited}}"
               name="textArea"></textarea>
     <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputTextAreaForm.textArea.$error.required" bo-text="i18n('validation.required')"></div>
   </div>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
@@ -1,9 +1,9 @@
-<div ng-form="inputTextArea">
+<div ng-form="inputTextAreaForm">
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
             ng-model="property.value" ng-trim="false"
             ng-required="{{property.metadata.properties.required}}"
             name="textArea"></textarea>
-  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextArea.textArea.$error.required" bo-text="i18n('validation.required')"></div>
+  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextAreaForm.textArea.$error.required" bo-text="i18n('validation.required')"></div>
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
             ng-model="property.value"
             disabled readonly></textarea>

--- a/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
@@ -1,6 +1,9 @@
-<div>
+<div ng-form="inputTextArea">
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
-            ng-model="property.value" ng-trim="false"></textarea>
+            ng-model="property.value" ng-trim="false"
+            ng-required="{{property.metadata.properties.mandatory}}"
+            name="textArea"></textarea>
+  <div class="coral-Form-errorlabel" ng-if="i18n('validation.required')" ng-show="inputTextArea.textArea.$error.required" bo-text="i18n('validation.required')"></div>
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
             ng-model="property.value"
             disabled readonly></textarea>

--- a/bundle/src/main/resources/angularjs-partials/propertyRow.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyRow.html
@@ -4,7 +4,7 @@
     bo-class="[property.overridden ? 'caconfig-property-overridden' : 'caconfig-property-not-overridden',
               (property.nestedConfig || property.nestedConfigCollection) ? 'caconfig-is-nested' : 'caconfig-not-nested']"
     bo-title="property.name" ng-cloak>
-  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.mandatory ? ' *' : '')"></td>
+  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.required ? ' *' : '')"></td>
 
   <td class="coral-Table-cell" ng-transclude>
     <!-- caconfig-property-input dynamically added here -->

--- a/bundle/src/main/resources/angularjs-partials/propertyRow.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyRow.html
@@ -4,7 +4,7 @@
     bo-class="[property.overridden ? 'caconfig-property-overridden' : 'caconfig-property-not-overridden',
               (property.nestedConfig || property.nestedConfigCollection) ? 'caconfig-is-nested' : 'caconfig-not-nested']"
     bo-title="property.name" ng-cloak>
-  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.required ? ' *' : '')"></td>
+  <td class="coral-Table-cell" bindonce="propertyRow" bo-text="(property.metadata.label || property.name) + (propertyRow.required ? ' *' : '')"></td>
 
   <td class="coral-Table-cell" ng-transclude>
     <!-- caconfig-property-input dynamically added here -->

--- a/bundle/src/main/resources/angularjs-partials/propertyRow.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyRow.html
@@ -4,7 +4,7 @@
     bo-class="[property.overridden ? 'caconfig-property-overridden' : 'caconfig-property-not-overridden',
               (property.nestedConfig || property.nestedConfigCollection) ? 'caconfig-is-nested' : 'caconfig-not-nested']"
     bo-title="property.name" ng-cloak>
-  <td class="coral-Table-cell" bo-text="property.metadata.label || property.name"></td>
+  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.mandatory ? ' *' : '')"></td>
 
   <td class="coral-Table-cell" ng-transclude>
     <!-- caconfig-property-input dynamically added here -->

--- a/bundle/src/main/resources/angularjs-partials/propertyRowPreview.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyRowPreview.html
@@ -4,7 +4,7 @@
                property.overridden ? 'caconfig-property-overridden' : 'caconfig-property-not-overridden',
               (property.nestedConfig || property.nestedConfigCollection) ? 'caconfig-is-nested' : 'caconfig-not-nested']"
     bo-title="property.name" ng-cloak>
-  <td class="coral-Table-cell" bo-text="property.metadata.label || property.name"></td>
+  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.mandatory ? ' *' : '')"></td>
   <td class="coral-Table-cell">
     <span class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited" bo-text="property.value"></span>
     <span class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited" bo-text="property.value"></span>

--- a/bundle/src/main/resources/angularjs-partials/propertyRowPreview.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyRowPreview.html
@@ -4,7 +4,7 @@
                property.overridden ? 'caconfig-property-overridden' : 'caconfig-property-not-overridden',
               (property.nestedConfig || property.nestedConfigCollection) ? 'caconfig-is-nested' : 'caconfig-not-nested']"
     bo-title="property.name" ng-cloak>
-  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.mandatory ? ' *' : '')"></td>
+  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.required ? ' *' : '')"></td>
   <td class="coral-Table-cell">
     <span class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited" bo-text="property.value"></span>
     <span class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited" bo-text="property.value"></span>

--- a/bundle/src/main/resources/angularjs-partials/propertyRowPreview.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyRowPreview.html
@@ -4,7 +4,7 @@
                property.overridden ? 'caconfig-property-overridden' : 'caconfig-property-not-overridden',
               (property.nestedConfig || property.nestedConfigCollection) ? 'caconfig-is-nested' : 'caconfig-not-nested']"
     bo-title="property.name" ng-cloak>
-  <td class="coral-Table-cell" bo-text="(property.metadata.label || property.name) + (property.metadata.properties.required ? ' *' : '')"></td>
+  <td class="coral-Table-cell" bo-text="property.metadata.label || property.name"></td>
   <td class="coral-Table-cell">
     <span class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited" bo-text="property.value"></span>
     <span class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited" bo-text="property.value"></span>

--- a/bundle/src/main/resources/i18n/de.json
+++ b/bundle/src/main/resources/i18n/de.json
@@ -89,6 +89,11 @@
         "allowed": "Erlaubte Zeichen: A-Z a-z 0-9 - _",
         "unique": "Dieser Name ist bereits in Verwendung."
       }
+    },
+
+    "validation": {
+      "required": "Füllen Sie dieses Feld aus."
     }
+
   }
 }

--- a/bundle/src/main/resources/i18n/en.json
+++ b/bundle/src/main/resources/i18n/en.json
@@ -89,6 +89,11 @@
         "allowed": "Allowed characters: A-Z a-z 0-9 - _",
         "unique": "This name is already in use."
       }
+    },
+
+    "validation": {
+      "required": "Please fill out this field."
     }
+
   }
 }

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/css/editor.css
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/css/editor.css
@@ -51,7 +51,13 @@ form.ng-dirty textarea.ng-dirty.ng-invalid,
 form.ng-dirty textarea.ng-dirty.ng-pending,
 form.ng-dirty input.ng-dirty.ng-invalid,
 form.ng-dirty input.ng-dirty.ng-pending {
-  border: 1px solid #f00;
+  border: 1px solid #d7373f;
+  /* This is taken over from CoralUI styling for _coral-Textfield.invalid */
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='18' viewBox='0 0 18 18' width='18'%3E%3Cpath style='fill:rgb%28227%2C 72%2C 80%29' d='M8.564 1.289L.2 16.256A.5.5 0 0 0 .636 17h16.728a.5.5 0 0 0 .5-.5.494.494 0 0 0-.064-.244L9.436 1.289a.5.5 0 0 0-.872 0zM10 14.75a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-1.5a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25zm0-3a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-6a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 18px 18px;
+  background-position: calc(100% - 11px) 6px;
+  padding-right: 41px;
 }
 
 form.ng-dirty .caconfig-if-form-pristine,

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/css/editor.css
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/css/editor.css
@@ -69,10 +69,6 @@ form.ng-pristine .caconfig-if-form-valid-and-dirty {
   display: none;
 }
 
-form div.caconfig-invalid-message {
-  color: #f00
-}
-
 span.caconfig-pathbrowser {
   width: 100% !important;
 }

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js.txt
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js.txt
@@ -1,5 +1,7 @@
 #base=js
 
+disableGraniteUiValidation.js
+
 app.module.js
 templates.module.js
 utilities.module.js

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/disableGraniteUiValidation.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/disableGraniteUiValidation.js
@@ -1,0 +1,18 @@
+/**
+ * Register custom validator to form fields inside caconfig editor
+ * to effectively suppress the default validation handling (e.g. for required fields)
+ * which otherwise would conflict with our AngularJS-based validation handling.
+ */
+(function(window, $) {
+  var registry = $(window).adaptTo("foundation-registry");
+  registry.register("foundation.validation.validator", {
+    selector: ".caconfig-detail input",
+    show: function() {
+      // ignore
+    },
+    clear: function() {
+      // ignore
+    }
+  });
+    
+})(window, Granite.$);

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/disableGraniteUiValidation.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/disableGraniteUiValidation.js
@@ -6,7 +6,7 @@
 (function(window, $) {
   var registry = $(window).adaptTo("foundation-registry");
   registry.register("foundation.validation.validator", {
-    selector: ".caconfig-detail input",
+    selector: ".caconfig-detail input, .caconfig-detail textarea, .caconfig-detail foundation-autocomplete",
     show: function() {
       // ignore
     },

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/multifield.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/multifield.directive.js
@@ -43,6 +43,8 @@
       var input = inputMap[scope.property.metadata.type];
       var inheritedStateChanged = false;
 
+      scope.i18n = $rootScope.i18n;
+
       scope.type = input.type;
       scope.pattern = input.pattern;
       scope.effectiveValues = [];

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -23,9 +23,9 @@
   angular.module("io.wcm.caconfig.widgets")
     .directive("caconfigPathbrowser", pathbrowser);
 
-  pathbrowser.$inject = ["templateUrlList", "directivePropertyPrefixes", "$timeout", "$rootScope", "configService", "pathbrowserService"];
+  pathbrowser.$inject = ["templateUrlList", "directivePropertyPrefixes", "$timeout", "$rootScope", "configService", "pathbrowserService", "$compile"];
 
-  function pathbrowser(templateList, directivePropertyPrefixes, $timeout, $rootScope, configService, pathbrowserService) {
+  function pathbrowser(templateList, directivePropertyPrefixes, $timeout, $rootScope, configService, pathbrowserService, $compile) {
     var directive = {
       replace: true,
       templateUrl: templateList.pathbrowser,
@@ -73,15 +73,22 @@
           suggestionOverlay.setAttribute("data-foundation-picker-buttonlist-src", pathbrowserService.getSuggestionSrc(options.rootPath));
 
           pathfieldWidget.value = scope.property.effectiveValue;
+          scope.property.value = scope.property.effectiveValue;
 
-          // Add change event listen
+          // bind model to input field (dynamically created by Coral UI)
+          var $input = $("input", pathfieldWidget);
+          $input.attr("name", "pathBrowser");
+          $input.attr("ng-required", props.required);
+          $input.attr("ng-model", "property.value");
+          $compile($input[0])(scope);
+
+          // Add change event listener
           $(pathfieldWidget).on("change", function onChange() {
             scope.property.value = pathfieldWidget.value;
-
             if ($rootScope.configForm.$pristine) {
               $rootScope.configForm.$setDirty();
-              scope.$digest();
             }
+            scope.$digest();
           });
         });
       });

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -44,6 +44,8 @@
       var pathfieldWidget;
       var suggestionOverlay;
 
+      scope.i18n = $rootScope.i18n;
+
       angular.forEach(props, function (value, prop) {
         var propName;
         // if the property starts with the prefix "pathbrowser" followed by a pathbrowser property name

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-input-checkbox.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-input-checkbox.directive.js
@@ -26,18 +26,23 @@
   angular.module("io.wcm.caconfig.widgets")
     .directive("caconfigPropertyInputCheckbox", propertyInputCheckbox);
 
-  propertyInputCheckbox.$inject = ["templateUrlList"];
+  propertyInputCheckbox.$inject = ["$rootScope", "templateUrlList"];
 
-  function propertyInputCheckbox(templateList) {
+  function propertyInputCheckbox($rootScope, templateList) {
 
     var directive = {
       templateUrl: templateList.propertyInputCheckbox,
       scope: {
         property: "="
       },
-      replace: true
+      replace: true,
+      link: link
     };
 
     return directive;
+
+    function link(scope) {
+      scope.i18n = $rootScope.i18n;
+    }
   }
 }(angular));

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-input-text.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-input-text.directive.js
@@ -26,9 +26,9 @@
   angular.module("io.wcm.caconfig.widgets")
     .directive("caconfigPropertyInputText", propertyInputText);
 
-  propertyInputText.$inject = ["templateUrlList", "inputMap"];
+  propertyInputText.$inject = ["$rootScope", "templateUrlList", "inputMap"];
 
-  function propertyInputText(templateList, inputMap) {
+  function propertyInputText($rootScope, templateList, inputMap) {
 
     var directive = {
       templateUrl: templateList.propertyInputText,
@@ -44,6 +44,7 @@
     function link(scope) {
       var input = inputMap[scope.property.metadata.type];
       scope.pattern = input.pattern;
+      scope.i18n = $rootScope.i18n;
 
       // Validation settings
       var props = scope.property.metadata.properties || {};

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-input-textarea.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-input-textarea.directive.js
@@ -26,9 +26,9 @@
   angular.module("io.wcm.caconfig.widgets")
     .directive("caconfigPropertyInputTextarea", propertyInputTextarea);
 
-  propertyInputTextarea.$inject = ["templateUrlList", "inputMap"];
+  propertyInputTextarea.$inject = ["$rootScope", "templateUrlList", "inputMap"];
 
-  function propertyInputTextarea(templateList, inputMap) {
+  function propertyInputTextarea($rootScope, templateList, inputMap) {
 
     var directive = {
       templateUrl: templateList.propertyInputTextarea,
@@ -44,6 +44,7 @@
     function link(scope) {
       var input = inputMap[scope.property.metadata.type];
       scope.pattern = input.pattern;
+      scope.i18n = $rootScope.i18n;
     }
   }
 }(angular));

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-row.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-row.directive.js
@@ -46,8 +46,20 @@
 
     function link(scope) {
       scope.propertyRow = {
-        handleInheritedChange: currentConfigService.handleInheritedChange
+        handleInheritedChange: currentConfigService.handleInheritedChange,
+        required: isRequired(scope)
       };
+    }
+
+    /**
+     * Check if this property is set as required.
+     * Also check if the widget types supports this, and ignore the setting if not.
+     */
+    function isRequired(scope) {
+      var props = scope.property.metadata.properties || {};
+      return (props.required == 'true'
+          && props.widgetType != 'tagbrowser'
+          && props.widgetType != 'dropdown');
     }
   }
 }(angular));

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/tagbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/tagbrowser.directive.js
@@ -40,8 +40,6 @@
     function link(scope, element) {
       var multiValue = scope.property.metadata.multivalue;
 
-      scope.i18n = $rootScope.i18n;
-
       if (multiValue) {
         scope.effectiveValues = [];
         scope.values = [];

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/tagbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/tagbrowser.directive.js
@@ -40,7 +40,9 @@
     function link(scope, element) {
       var multiValue = scope.property.metadata.multivalue;
 
-      if(multiValue) {
+      scope.i18n = $rootScope.i18n;
+
+      if (multiValue) {
         scope.effectiveValues = [];
         scope.values = [];
 

--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.13.0" date="not released">
+      <action type="add" dev="sseifert">
+        Add support for defining properties as "required", forcing users to enter a value.
+      </action>
+    </release>
+
     <release version="1.12.2" date="2022-08-24">
       <action type="fix" dev="sseifert">
         Ensure property descriptions containing special characters like &lt;&gt; are properly escaped.

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>io.wcm</groupId>
     <artifactId>io.wcm.caconfig.editor.parent</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.caconfig.editor.package</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <packaging>content-package</packaging>
   <url>${site.url}/caconfig/editor/</url>
 
@@ -40,7 +40,7 @@
     <contentPackage.group>wcm-io</contentPackage.group>
 
     <!-- Enable reproducible builds -->
-    <project.build.outputTimestamp>2022-08-24T11:41:54Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2022-09-20T14:22:41Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>
@@ -49,7 +49,7 @@
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.caconfig.editor</artifactId>
       <scope>compile</scope>
-      <version>1.12.3-SNAPSHOT</version>
+      <version>1.13.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,12 +26,12 @@
     <groupId>io.wcm</groupId>
     <artifactId>io.wcm.parent_toplevel</artifactId>
     <version>2.1.0</version>
-    <relativePath/>
+    <relativePath />
   </parent>
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.caconfig.editor.parent</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Context-Aware Configuration Editor</name>
@@ -39,7 +39,7 @@
   
   <properties>
     <!-- Enable reproducible builds -->
-    <project.build.outputTimestamp>2022-08-24T11:41:54Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2022-09-20T14:22:41Z</project.build.outputTimestamp>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>io.wcm</groupId>
     <artifactId>io.wcm.caconfig.editor.parent</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.caconfig.editor.root</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Context-Aware Configuration Editor</name>


### PR DESCRIPTION
allow to mark caconfig properties as required/mandatory to prevent saving incomplete configurations.

supports all property data types/widget types **except** tagbrowser, dropdown.