### PR TITLE
Fix toTop/toBottom scrolling buttons

### DIFF
--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/editor/detail.controller.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/editor/detail.controller.js
@@ -152,11 +152,12 @@
     };
 
     that.toBottom = function() {
-      $document.find("html, body").animate({scrollTop: document.body.scrollHeight});
+      var $content = $document.find('coral-shell-content');
+      $content.animate({scrollTop: $content[0].scrollHeight});
     };
 
     that.toTop = function() {
-      $document.find("html, body").animate({scrollTop: 0});
+      $document.find('coral-shell-content').animate({scrollTop: 0});
     };
 
     /**

--- a/changes.xml
+++ b/changes.xml
@@ -36,6 +36,9 @@
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.17 as minimum version.
       </action>
+      <action type="fix" dev="mpankratiev" issue="32">
+        Fix toTop/toBottom scrolling buttons.
+      </action>
     </release>
 
     <release version="1.15.8" date="2023-11-22">


### PR DESCRIPTION
Scrolling behaviour does not work in the html and body tags on the Config Editor page -> html and body tags have height = 0.

<img width="1726" alt="image" src="https://github.com/wcm-io/io.wcm.caconfig.editor/assets/153524023/d6bed835-fbfd-4b72-8c67-7612938ce935">

Fixes #33
