### PR TITLE
Prevent view reload when actual view parameters do not change

### DIFF
--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/editor/editor.module.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/editor/editor.module.js
@@ -47,6 +47,21 @@
     $rootScope.i18n = function (key) {
       return Granite.I18n.get("io.wcm.caconfig.editor." + key);
     };
+
+    $rootScope.$on('$routeChangeStart', function(event, next, current) {
+      if (isSameRoute(current, next)) {
+        // avoid reload when route is the same as before
+        event.preventDefault();
+      }
+    });
+  }
+
+  function isSameRoute(current, next) {
+    const currentController = current?.$$route?.controller;
+    const currentConfigName = current?.pathParams?.configName;
+    const nextController = next?.$$route?.controller;
+    const nextConfigName = current?.pathParams?.configName;
+    return currentController !== undefined && currentController === nextController && currentConfigName === nextConfigName;
   }
 
 }(angular, Granite));

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -84,11 +84,13 @@
 
           // Add change event listener
           $(pathfieldWidget).on("change", function onChange() {
-            scope.property.value = pathfieldWidget.value;
-            if ($rootScope.configForm.$pristine) {
-              $rootScope.configForm.$setDirty();
+            if (scope.property.value != pathfieldWidget.value) {
+              scope.property.value = pathfieldWidget.value;
+              if ($rootScope.configForm.$pristine) {
+                $rootScope.configForm.$setDirty();
+              }
+              scope.$digest();
             }
-            scope.$digest();
           });
         });
       });


### PR DESCRIPTION
also update pathbrowser widget: trigger scope update only if value actually has changed

Fixes #37 

background:
* the problem described in #37 only happens in AEMaaCS cloud instances where the Unified Shell is active. it seems this gets in conflict with the AngularJS routing the first them the editor JS code calls `$dispatch()` manually, e.g. after updating the value picked in the pathbrowser widget.
* to prevent this a listener is introduced that prevents route changes if the actual routing parameters (controller, path parameters) are not changed