### PR TITLE
Ensure templates.module.js is included in JAR files

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -35,3 +35,4 @@ jobs:
           sonar-run-on-java-version: 17
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          maven-additional-args: -X

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -35,4 +35,3 @@ jobs:
           sonar-run-on-java-version: 17
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          maven-additional-args: -X

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -218,7 +218,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
-          <addDefaultExcludes>false</addDefaultExcludes>
+          <useBuildFilters>false</useBuildFilters>
         </configuration>
       </plugin>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -252,6 +252,31 @@
         </executions>
       </plugin>
 
+      <!-- Ensure generated templates file exist -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-files-exist</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <requireFilesExist>
+                  <files>
+                   <file>${project.build.outputDirectory}/SLING-INF/app-root/clientlibs/io.wcm.caconfig.editor/js/templates.module.js</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>io.wcm.maven.plugins</groupId>
         <artifactId>i18n-maven-plugin</artifactId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -214,6 +214,14 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <addDefaultExcludes>false</addDefaultExcludes>
+        </configuration>
+      </plugin>
+
       <!-- Nodejs Maven Plugin to run the templates compilation and tests -->
       <plugin>
         <groupId>com.github.eirslett</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -208,6 +208,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <addDefaultExcludes>false</addDefaultExcludes>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
@@ -275,7 +276,7 @@
             </configuration>
           </execution>
           <execution>
-            <id>enforce-exist-templates.module.js</id>
+            <id>enforce-exist-templates.module.js-classes</id>
             <goals>
               <goal>enforce</goal>
             </goals>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -165,7 +165,7 @@
         <excludes>
           <!-- those resources are processed by the i18n-maven-plugin -->
           <exclude>i18n/**</exclude>
-          <!-- processed by grund html2js -->
+          <!-- processed by grunt html2js -->
           <exclude>angularjs-partials/**</exclude>
         </excludes>
       </resource>
@@ -208,7 +208,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
-          <addDefaultExcludes>false</addDefaultExcludes>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -258,24 +258,7 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-exist-templates.module.js-src</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>compile</phase>
-            <configuration>
-              <rules>
-                <requireFilesExist>
-                  <files>
-                   <file>src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/templates.module.js</file>
-                  </files>
-                </requireFilesExist>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-exist-templates.module.js-classes</id>
+            <id>enforce-exist-templates.module.js</id>
             <goals>
               <goal>enforce</goal>
             </goals>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -214,14 +214,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <configuration>
-          <useBuildFilters>false</useBuildFilters>
-        </configuration>
-      </plugin>
-
       <!-- Nodejs Maven Plugin to run the templates compilation and tests -->
       <plugin>
         <groupId>com.github.eirslett</groupId>
@@ -232,7 +224,7 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <phase>process-resources</phase>
+            <phase>generate-resources</phase>
             <configuration>
               <nodeVersion>v20.11.1</nodeVersion>
             </configuration>
@@ -242,7 +234,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>process-resources</phase>
+            <phase>generate-resources</phase>
             <configuration>
               <arguments>install</arguments>
             </configuration>
@@ -252,7 +244,7 @@
             <goals>
               <goal>grunt</goal>
             </goals>
-            <phase>process-resources</phase>
+            <phase>generate-resources</phase>
             <configuration>
               <arguments>build</arguments>
             </configuration>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -258,7 +258,24 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-files-exist</id>
+            <id>enforce-exist-templates.module.js-src</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <rules>
+                <requireFilesExist>
+                  <files>
+                   <file>src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/templates.module.js</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-exist-templates.module.js</id>
             <goals>
               <goal>enforce</goal>
             </goals>


### PR DESCRIPTION
We had problems that `SLING-INF/app-root/clientlibs/io.wcm.caconfig.editor/js/templates.module.js` is missing from the JAR file when building with GitHub actions.