### PR TITLE
Support "required" for dropdown properties

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,85 @@
+# Copilot Instructions for io.wcm.caconfig.editor
+
+## Project Purpose
+
+This project provides a context-aware configuration editor for AEM.
+
+- The backend is implemented in Java as OSGi services and Sling servlets.
+- The frontend is implemented primarily with AngularJS 1.x.
+- The UI is embedded into the AEM author/admin experience and must fit into AEM's CoralUI and Granite styling.
+- The frontend is not a pure CoralUI app and not a generic AngularJS app. CoralUI provides visual structure and selected widget behavior, while AngularJS owns most field behavior, data binding, validation, and user interaction.
+
+When generating code, preserve this hybrid architecture instead of trying to rewrite existing functionality toward modern frontend frameworks or pure Coral widget implementations.
+
+## Repository Layout
+
+- `bundle/src/main/java/io/wcm/caconfig/editor`: Java API, models, OSGi services, Sling servlets, and response generation.
+- `bundle/src/test/java`: backend unit tests.
+- `bundle/src/main/resources/angularjs-partials`: AngularJS HTML partials used as directive templates and compiled into the frontend template module.
+- `bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js`: application-specific AngularJS modules, controllers, services, directives, and modal logic.
+- `bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/css`: editor styling and Coral helper CSS.
+- `bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor.angularjs`: vendored AngularJS runtime libraries.
+- `package/jcr_root`: AEM package content.
+
+## Frontend Rules
+
+- Treat AngularJS 1.x as the primary frontend implementation model.
+- Keep using the existing AngularJS module, controller, service, and directive patterns already present in the clientlibs.
+- Keep templates in `bundle/src/main/resources/angularjs-partials` and the related directive or controller logic in the AEM clientlib JavaScript.
+- If a UI change affects a template in `angularjs-partials`, also check whether the corresponding directive or controller in the clientlib must be updated.
+- Remember that Grunt compiles the HTML partials into `templates.module.js`. Do not hand-edit generated output unless the repository already expects it.
+- Reuse existing clientlib modules and naming conventions such as `*.module.js`, `*.service.js`, `*.controller.js`, and `*.directive.js`.
+- Prefer the existing AngularJS dependency injection style using explicit `$inject` arrays.
+
+## CoralUI and AEM Integration Rules
+
+- Preserve AEM and CoralUI compatibility first.
+- Reuse existing Coral markup, CSS classes, and widget initialization patterns instead of replacing them with custom HTML controls.
+- When changing field widgets, account for both Coral widget state and AngularJS model state.
+- Be careful with dynamic Coral widgets that create or wrap DOM elements at runtime. Existing code may need manual event binding, delayed initialization, or `$compile` integration to keep AngularJS validation and model binding working.
+- Do not assume Granite or Coral validation is sufficient. Check how AngularJS forms, `ng-model`, `ng-required`, error labels, and dirty/pristine handling are implemented before changing validation behavior.
+- Match the existing admin UI look and behavior. Avoid introducing styling or interaction patterns that feel separate from AEM.
+
+## Backend Rules
+
+- Follow existing Java, Sling, and OSGi patterns in `bundle/src/main/java`.
+- Keep Sling servlet resource types, selectors, and extension mappings consistent with existing code.
+- Prefer extending existing response models and services over adding parallel ad hoc JSON generation.
+- Keep logic that derives editor metadata, dropdown options, browser roots, validation metadata, or persisted configuration behavior in the backend where similar functionality already lives.
+- Add or update backend tests for behavioral changes whenever practical.
+
+## Change Strategy
+
+- Make minimal, targeted changes that fit the current architecture.
+- Do not migrate AngularJS code to React, Vue, or newer Angular.
+- Do not replace clientlibs, CoralUI integration, or AEM packaging conventions with modern bundlers unless explicitly requested.
+- Avoid broad refactors unless the task requires them.
+- For frontend features, check whether the change spans all of these layers:
+  - backend property metadata or JSON output
+  - AngularJS directive or controller behavior
+  - AngularJS partial template markup
+  - CSS for Coral-aligned rendering
+
+## Validation and Build Expectations
+
+Before finishing a change, use the smallest relevant validation available:
+
+- Backend changes: run Maven tests relevant to the bundle module when feasible.
+- Frontend JavaScript changes: run the Grunt or ESLint tasks in `bundle` when feasible.
+- Template changes: regenerate compiled AngularJS templates with the Grunt build.
+
+Useful commands:
+
+- `mvn clean install`
+- `mvn -pl bundle test`
+- in `bundle`: `npm install`
+- in `bundle`: `grunt build`
+- in `bundle`: `grunt lint:js`
+
+## Implementation Guidance for Copilot
+
+- When asked to implement a field or validation change, inspect both the backend metadata source and the frontend directive/template pair before editing.
+- When asked to change dropdowns, path browsers, tag browsers, or multifields, expect custom integration code that bridges Coral widgets and AngularJS forms.
+- When adding validation, ensure the UI state, AngularJS form state, and persisted value semantics stay aligned.
+- When generating examples or fixes, prefer patterns already used in this repository over generic AEM or AngularJS examples.
+- Keep generated code compatible with the repository's existing Java version, Maven build, AngularJS style, and clientlib packaging.

--- a/bundle/src/main/resources/angularjs-partials/propertyDropdown.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyDropdown.html
@@ -14,7 +14,7 @@
       <coral-icon class="coral3-Icon coral3-Select-openIcon coral3-Icon--chevronDown coral3-Icon--sizeXS" icon="chevronDown" size="XS"></coral-icon>
       <span class="coral3-Select-label" bo-if="i18n('button.choose')" bo-text="i18n('button.choose')"></span>
     </button>
-    <coral-taglist class="coral3-Select-tagList caconfig-dummy-taglist"></coral-taglist>
+    <coral-taglist class="coral3-Select-tagList caconfig-dummy-taglist" disabled readonly></coral-taglist>
   </span>
 
   <span class="coral-Select coral3-Select caconfig-if-property-overridden-or-inherited-or-readonly">
@@ -22,6 +22,6 @@
       <coral-icon class="coral3-Icon coral3-Select-openIcon coral3-Icon--chevronDown coral3-Icon--sizeXS" icon="chevronDown" size="XS"></coral-icon>
       <span class="coral3-Select-label" ng-bind="getOptionText(property.effectiveValue)"></span>
     </button>
-    <coral-taglist class="coral3-Select-tagList caconfig-dummy-taglist caconfig-dummy-taglist--effective"></coral-taglist>
+    <coral-taglist class="coral3-Select-tagList caconfig-dummy-taglist caconfig-dummy-taglist--effective" disabled readonly></coral-taglist>
   </span>
 </div>

--- a/bundle/src/main/resources/angularjs-partials/propertyDropdown.html
+++ b/bundle/src/main/resources/angularjs-partials/propertyDropdown.html
@@ -1,11 +1,13 @@
-<div class="caconfig-property-dropdown" bindonce="dropdownReady" ng-model="property.value">
-  <coral-select class="caconfig-if-property-not-overridden-and-not-inherited-and-not-readonly caconfig-if-config-not-inherited" bo-id="id"
-                bo-attr bo-attr-placeholder="i18n('button.choose')">
-    <coral-select-item ng-repeat="option in dropdownOptions"
-                       bo-value="option.value"
-                       bo-text="option.description">
-    </coral-select-item>
-  </coral-select>
+<div class="caconfig-property-dropdown" bindonce="dropdownReady" ng-form="inputDropdownForm">
+  <div class="caconfig-if-property-not-overridden-and-not-inherited-and-not-readonly caconfig-if-config-not-inherited">
+    <coral-select bo-id="id" bo-attr bo-attr-placeholder="i18n('button.choose')">
+      <coral-select-item ng-repeat="option in dropdownOptions"
+                         bo-value="option.value"
+                         bo-text="option.description">
+      </coral-select-item>
+    </coral-select>
+    <div class="coral-Form-errorlabel" bindonce="i18n('validation.required')" ng-show="inputDropdownForm.dropDown.$error.required" bo-text="i18n('validation.required')"></div>
+  </div>
 
   <span class="coral-Select coral3-Select caconfig-if-property-not-overridden-and-not-inherited-and-not-readonly caconfig-if-config-inherited">
     <button class="coral3-Button coral3-Button--secondary coral3-Button--block coral3-Select-button" disabled readonly>

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/disableGraniteUiValidation.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/disableGraniteUiValidation.js
@@ -6,7 +6,7 @@
 (function(window, $) {
   var registry = $(window).adaptTo("foundation-registry");
   registry.register("foundation.validation.validator", {
-    selector: ".caconfig-detail input, .caconfig-detail textarea, .caconfig-detail foundation-autocomplete",
+    selector: ".caconfig-detail input, .caconfig-detail textarea, .caconfig-detail foundation-autocomplete, .caconfig-detail coral-select",
     show: function() {
       // ignore
     },

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -78,7 +78,7 @@
           // bind model to input field (dynamically created by Coral UI)
           var $input = $("input", pathfieldWidget);
           $input.attr("name", "pathBrowser");
-          $input.attr("ng-required", props.required);
+          $input.attr("ng-required", "property.metadata.properties.required && !property.overridden && !property.readOnly && !property.inherited");
           $input.attr("ng-model", "property.value");
           if (props.validation) {
             $input.attr("caconfig-validation", props.validation);

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -39,7 +39,7 @@
 
     function link(scope, element) {
       var prefix = directivePropertyPrefixes.pathbrowser;
-      var props = scope.property.metadata.properties;
+      var props = scope.property.metadata.properties || {};
       var options = {};
       var pathfieldWidget;
       var suggestionOverlay;

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
@@ -149,14 +149,14 @@
           $input.attr("ng-model", "property.value");
           $compile($input[0])(scope);
 
-          // Add change event listen
+          // Add change event listener
           selectWidget.on("change", function onChange() {
             scope.property.value = getValue(selectWidget, inputType);
 
             if ($rootScope.configForm.$pristine) {
               $rootScope.configForm.$setDirty();
-              scope.$digest();
             }
+            scope.$digest();
           });
         });
       });

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
@@ -49,15 +49,13 @@
         $dummyTagLists;
       var input = inputMap[scope.property.metadata.type];
       var inputType = input.type;
-      var props = scope.property.metadata.properties;
+      var props = scope.property.metadata.properties || {};
       var isRequired = props && (props.required === true || props.required === "true");
 
       scope.id = Coral.commons.getUID();
 
-      scope.dropdownOptions = [];
-      if (props && props.dropdownOptions) {
-        scope.dropdownOptions = props.dropdownOptions;
-      }
+      // clone array to avoid modifying original array in case of adding blank option for non-required single selection
+      scope.dropdownOptions = (props.dropdownOptions || []).slice();
 
       // for optional single-selection add blank option as first option
       if (!scope.multivalue && !isRequired) {

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
@@ -26,9 +26,9 @@
   angular.module("io.wcm.caconfig.widgets")
     .directive("caconfigPropertyDropdown", propertyDropdown);
 
-  propertyDropdown.$inject = ["$rootScope", "$timeout", "templateUrlList", "inputMap"];
+  propertyDropdown.$inject = ["$rootScope", "$timeout", "templateUrlList", "inputMap", "$compile"];
 
-  function propertyDropdown($rootScope, $timeout, templateList, inputMap) {
+  function propertyDropdown($rootScope, $timeout, templateList, inputMap, $compile) {
     var directive = {
       templateUrl: templateList.propertyDropdown,
       scope: {
@@ -49,12 +49,13 @@
         $dummyTagLists;
       var input = inputMap[scope.property.metadata.type];
       var inputType = input.type;
+      var props = scope.property.metadata.properties;
 
       scope.id = Coral.commons.getUID();
 
       scope.dropdownOptions = [];
-      if (scope.property.metadata.properties && scope.property.metadata.properties.dropdownOptions) {
-        scope.dropdownOptions = scope.property.metadata.properties.dropdownOptions;
+      if (props && props.dropdownOptions) {
+        scope.dropdownOptions = props.dropdownOptions;
       }
 
       // if single-selection add blank option as first option
@@ -140,6 +141,13 @@
               }
             });
           }
+
+          // bind model to select field (dynamically created by Coral UI)
+          var $input = $("select", selectWidget);
+          $input.attr("name", "dropDown");
+          $input.attr("ng-required", props.required);
+          $input.attr("ng-model", "property.value");
+          $compile($input[0])(scope);
 
           // Add change event listen
           selectWidget.on("change", function onChange() {

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
@@ -144,7 +144,7 @@
           // bind model to select field (dynamically created by Coral UI)
           var $input = $("select", selectWidget);
           $input.attr("name", "dropDown");
-          $input.attr("ng-required", props.required);
+          $input.attr("ng-required", "property.metadata.properties.required && !property.overridden && !property.readOnly && !property.inherited");
           $input.attr("ng-model", "property.value");
           $compile($input[0])(scope);
 

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-dropdown.directive.js
@@ -50,6 +50,7 @@
       var input = inputMap[scope.property.metadata.type];
       var inputType = input.type;
       var props = scope.property.metadata.properties;
+      var isRequired = props && (props.required === true || props.required === "true");
 
       scope.id = Coral.commons.getUID();
 
@@ -58,8 +59,8 @@
         scope.dropdownOptions = props.dropdownOptions;
       }
 
-      // if single-selection add blank option as first option
-      if (!scope.multivalue) {
+      // for optional single-selection add blank option as first option
+      if (!scope.multivalue && !isRequired) {
         scope.dropdownOptions.unshift({
           value: "",
           description: ""

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-row.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/property-row.directive.js
@@ -59,8 +59,7 @@
       var metadata = scope.property.metadata || {};
       var props = metadata.properties || {};
       return (props.required == 'true'
-          && props.widgetType != 'tagbrowser'
-          && props.widgetType != 'dropdown');
+          && props.widgetType != 'tagbrowser');
     }
   }
 }(angular));

--- a/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/tagbrowser.directive.js
+++ b/bundle/src/main/webapp/app-root/clientlibs/io.wcm.caconfig.editor/js/widgets/tagbrowser.directive.js
@@ -49,7 +49,7 @@
       }
 
       var prefix = directivePropertyPrefixes.tagbrowser;
-      var props = scope.property.metadata.properties;
+      var props = scope.property.metadata.properties || {};
 
       var tagfieldName = "tags-" + Coral.commons.getUID();
 

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,15 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="1.17.0" date="not released">
+      <action type="add" dev="sseifert" issue="79">
+        Add support for required feature for for dropdown widget type. Don't add a "blank" entry for single-valued dropdown lists marked as required.
+      </action>
+      <action type="fix" dev="sseifert" issue="79">
+        Fix behavior of pathbrowser widget marked as required when used with inheritance/braking inheritance for individual properties.
+      </action>
+    </release>
+
     <release version="1.16.10" date="2026-02-24">
       <action type="fix" dev="sseifert" issue="73">
         Strip comments from JSON Files in Sling-Initial-Content to fix deployment problem in AEM 6.6.2 (AEM 6.5 LTS SP 2).

--- a/src/site/markdown/validation.md
+++ b/src/site/markdown/validation.md
@@ -36,6 +36,34 @@ Validation support is implemented for the following widget types:
 * `pathbrowser`
 
 
+### Required fields
+
+You can mark fields as mandatory with the `required` property.
+
+Example:
+
+```java
+@Property(label = "Title", property = {
+  "required=true"
+})
+String title();
+```
+
+When `required=true` is configured, the editor prevents saving until a value is entered.
+
+Required field support is implemented for the following widget types:
+
+* `textfield`
+* `textarea`
+* `checkbox`
+* `pathbrowser`
+* `dropdown`
+
+Required field support is currently **not** implemented for:
+
+* `tagbrowser`
+
+
 ### Validating with Granite UI foundation validators
 
 AEM provides very few built-in validators to be used in edit dialogs, but they can be added via 3rd-party libraries like [wcm.io WCM Granite UI Extensions][wcmio-graniteui-extensions] or implemented within the AEM project ([example][graniteui-foundation-validator-example]).


### PR DESCRIPTION
* Add support for `required` feature for for `dropdown` widget type
* Don't add a "blank" entry for single-valued dropdown lists marked as required
* Fix behavior of 'dropdown' and 'pathbrowser' widget marked as required when used with inheritance/braking inheritance for individual properties
* Update documentation for `required` feature

Fixes #76 